### PR TITLE
Remove Pygment and Redcarpet gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,8 @@ group :jekyll_plugins do
   gem "jekyll-paginate"
 end
 
-gem "redcarpet"
-gem "pygments.rb"
+# gem "redcarpet"
+# gem "pygments.rb"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,6 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.3)
-    multi_json (1.13.1)
     multipart-post (2.1.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
@@ -213,12 +212,9 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.1.1)
-    pygments.rb (1.2.1)
-      multi_json (>= 1.0.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    redcarpet (3.4.0)
     rouge (2.2.1)
     ruby-enum (0.7.2)
       i18n
@@ -248,8 +244,6 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll-paginate
-  pygments.rb
-  redcarpet
   tzinfo-data
 
 BUNDLED WITH


### PR DESCRIPTION
These gem has been removed from latest jekyll.
redcarpet -> kramdown
pygment -> rouge